### PR TITLE
Added benchmarks for Claude Sonnet 3.5

### DIFF
--- a/forecasting_tools/ai_models/claude35sonnet.py
+++ b/forecasting_tools/ai_models/claude35sonnet.py
@@ -8,8 +8,11 @@ from forecasting_tools.ai_models.model_archetypes.anthropic_text_model import (
 class Claude35Sonnet(AnthropicTextToTextModel):
     # See Anthropic Limit on the account dashboard for most up-to-date limit
     MODEL_NAME: Final[str] = "claude-3-5-sonnet-20240620"
-    REQUESTS_PER_PERIOD_LIMIT: Final[int] = 50
+    # Latest as of Nov 6 2024 is claude-2-5-sonnet-20241022
+    # Latest in general is claude-3-5-sonnet-latest
+    # See models here https://docs.anthropic.com/en/docs/about-claude/models
+    REQUESTS_PER_PERIOD_LIMIT: Final[int] = 40
     REQUEST_PERIOD_IN_SECONDS: Final[int] = 60
     TIMEOUT_TIME: Final[int] = 40
-    TOKENS_PER_PERIOD_LIMIT: Final[int] = 40000
+    TOKENS_PER_PERIOD_LIMIT: Final[int] = 35_000
     TOKEN_PERIOD_IN_SECONDS: Final[int] = 60

--- a/forecasting_tools/ai_models/claude35sonnet.py
+++ b/forecasting_tools/ai_models/claude35sonnet.py
@@ -7,12 +7,12 @@ from forecasting_tools.ai_models.model_archetypes.anthropic_text_model import (
 
 class Claude35Sonnet(AnthropicTextToTextModel):
     # See Anthropic Limit on the account dashboard for most up-to-date limit
-    MODEL_NAME: Final[str] = "claude-3-5-sonnet-20240620"
     # Latest as of Nov 6 2024 is claude-2-5-sonnet-20241022
     # Latest in general is claude-3-5-sonnet-latest
     # See models here https://docs.anthropic.com/en/docs/about-claude/models
-    REQUESTS_PER_PERIOD_LIMIT: Final[int] = 40
+    MODEL_NAME: Final[str] = "claude-3-5-sonnet-20240620"
+    REQUESTS_PER_PERIOD_LIMIT: Final[int] = 1_750
     REQUEST_PERIOD_IN_SECONDS: Final[int] = 60
     TIMEOUT_TIME: Final[int] = 40
-    TOKENS_PER_PERIOD_LIMIT: Final[int] = 35_000
+    TOKENS_PER_PERIOD_LIMIT: Final[int] = 140_000
     TOKEN_PERIOD_IN_SECONDS: Final[int] = 60

--- a/forecasting_tools/ai_models/exa_searcher.py
+++ b/forecasting_tools/ai_models/exa_searcher.py
@@ -62,10 +62,10 @@ class SearchInput(BaseModel, Jsonable):
         description="The query to search within each document using semantic similarity"
     )
     include_domains: list[str] = Field(
-        description="List of domains to require in the search results for example: ['youtube.com', 'en.wikipedia.org']. An empty list means no filter."
+        description="List of domains to require in the search results for example: ['youtube.com', 'en.wikipedia.org']. An empty list means no filter. This will constrain search to ONLY results from these domains."
     )
     exclude_domains: list[str] = Field(
-        description="List of domains to exclude from the search results: ['youtube.com', 'en.wikipedia.org']. An empty list means no filter."
+        description="List of domains to exclude from the search results: ['youtube.com', 'en.wikipedia.org']. An empty list means no filter. This will constrain search to exclude results from these domains."
     )
     include_text: str | None = Field(
         description="A 1-5 word phrase that must be exactly present in the text of the search results"

--- a/forecasting_tools/forecasting/llms/configured_llms.py
+++ b/forecasting_tools/forecasting/llms/configured_llms.py
@@ -1,10 +1,11 @@
-from forecasting_tools.ai_models.claude35sonnet import Claude35Sonnet
+from forecasting_tools.ai_models.gpt4o import Gpt4o
+from forecasting_tools.ai_models.gpto1 import GptO1
 
 
-class BasicLlm(Claude35Sonnet):
+class BasicLlm(Gpt4o):
     # NOTE: If need be, you can force an API key here through OpenAI Client class variable
     pass
 
 
-class AdvancedLlm(Claude35Sonnet):
+class AdvancedLlm(GptO1):
     pass

--- a/forecasting_tools/forecasting/llms/configured_llms.py
+++ b/forecasting_tools/forecasting/llms/configured_llms.py
@@ -1,11 +1,10 @@
-from forecasting_tools.ai_models.gpt4o import Gpt4o
-from forecasting_tools.ai_models.gpto1 import GptO1
+from forecasting_tools.ai_models.claude35sonnet import Claude35Sonnet
 
 
-class BasicLlm(Gpt4o):
+class BasicLlm(Claude35Sonnet):
     # NOTE: If need be, you can force an API key here through OpenAI Client class variable
     pass
 
 
-class AdvancedLlm(GptO1):
+class AdvancedLlm(Claude35Sonnet):
     pass

--- a/forecasting_tools/forecasting/llms/smart_searcher.py
+++ b/forecasting_tools/forecasting/llms/smart_searcher.py
@@ -94,6 +94,7 @@ class SmartSearcher(OutputsText, AiModel):
             {self.llm.get_schema_format_instructions_for_pydantic_type(SearchInput)}
 
             Make sure to return a list of the search inputs as a list of JSON objects in this schema.
+            Do not give the json in separate chunks. It needs to be in one combined list.
             """
         )
         search_terms = await self.llm.invoke_and_return_verified_type(

--- a/front_end/app_pages/benchmark_page.py
+++ b/front_end/app_pages/benchmark_page.py
@@ -17,7 +17,8 @@ class BenchmarkPage(AppPage):
     BENCHMARK_FILE_SELECTBOX_KEY: str = "benchmark_file_selectbox"
     BENCHMARK_FILES_TO_SHOW: dict[str, str] = {
         "GPT-4O for research and GPT-O1 for final decision": "2024-11-06_00-05-28__q4_initial_bot__score_0.0079__git_b666874.json",
-        "Claude 3.5 Sonnet": "2024-11-06_11-05-17__q4_initial_bot_with_anthropic__score_0.0092.json",
+        "Claude 3.5 Sonnet for all tasks": "2024-11-06_19-32-35__q4_initial_bot_anthropic__score_0.024__git_a7572c1.json",
+        # "Claude 3.5 Sonnet Incomplete (5 questions)": "2024-11-06_11-05-17__q4_initial_bot_with_anthropic__score_0.0092.json",
         # "Research Format Update": "2024-08-30_17-22-42__research_format_update__score_0.0802.json",
         # "Original Bot": "2024-08-30_16-46-19__original_bot__score_0.0657.json",
     }
@@ -25,7 +26,7 @@ class BenchmarkPage(AppPage):
 
     @classmethod
     async def _async_main(cls) -> None:
-        st.title("Benchmarks")
+        st.title("📈 Benchmarking Forecast Bot")
         st.write("")
         selected_file = st.selectbox(
             "Select a benchmark file:",

--- a/front_end/app_pages/benchmark_page.py
+++ b/front_end/app_pages/benchmark_page.py
@@ -17,6 +17,7 @@ class BenchmarkPage(AppPage):
     BENCHMARK_FILE_SELECTBOX_KEY: str = "benchmark_file_selectbox"
     BENCHMARK_FILES_TO_SHOW: dict[str, str] = {
         "GPT-4O for research and GPT-O1 for reasoning": "2024-11-06_00-05-28__q4_initial_bot__score_0.0079__git_b666874.json",
+        "Claude 3.5 Sonnet": "2024-11-06_11-05-17__q4_initial_bot_with_anthropic__score_0.0092.json",
         # "Research Format Update": "2024-08-30_17-22-42__research_format_update__score_0.0802.json",
         # "Original Bot": "2024-08-30_16-46-19__original_bot__score_0.0657.json",
     }

--- a/front_end/app_pages/benchmark_page.py
+++ b/front_end/app_pages/benchmark_page.py
@@ -16,7 +16,7 @@ class BenchmarkPage(AppPage):
     URL_PATH: str = "/benchmark"
     BENCHMARK_FILE_SELECTBOX_KEY: str = "benchmark_file_selectbox"
     BENCHMARK_FILES_TO_SHOW: dict[str, str] = {
-        "GPT-4O for research and GPT-O1 for reasoning": "2024-11-06_00-05-28__q4_initial_bot__score_0.0079__git_b666874.json",
+        "GPT-4O for research and GPT-O1 for final decision": "2024-11-06_00-05-28__q4_initial_bot__score_0.0079__git_b666874.json",
         "Claude 3.5 Sonnet": "2024-11-06_11-05-17__q4_initial_bot_with_anthropic__score_0.0092.json",
         # "Research Format Update": "2024-08-30_17-22-42__research_format_update__score_0.0802.json",
         # "Original Bot": "2024-08-30_16-46-19__original_bot__score_0.0657.json",


### PR DESCRIPTION
Generated by copilot:
This pull request includes several updates across different files to improve the functionality and documentation of the forecasting tools and front-end application. The most important changes include updating model limits and descriptions, enhancing search input constraints, and refining benchmark page details.

Updates to model limits and descriptions:

* [`forecasting_tools/ai_models/claude35sonnet.py`](diffhunk://#diff-eb33a43e9e067ff74bcfe80b0ca5435f75914c38c507d0a55db9eec36ab20393R10-R17): Updated the `REQUESTS_PER_PERIOD_LIMIT` to 1,750 and `TOKENS_PER_PERIOD_LIMIT` to 140,000. Added comments about the latest model versions.

Enhancements to search input constraints:

* [`forecasting_tools/ai_models/exa_searcher.py`](diffhunk://#diff-f782ccd0e20c1d05022bb6eddddbe808412b09a58c8e7fb25620245f135d0ec1L65-R68): Clarified descriptions for `include_domains` and `exclude_domains` fields to specify that they constrain the search results to only include or exclude specified domains.
* [`forecasting_tools/forecasting/llms/smart_searcher.py`](diffhunk://#diff-f348d390efa6cd5323e522f930014245ecc73dee394c026d2c03243dadc434c2R97): Added instruction to return JSON in one combined list instead of separate chunks.

Refinements to benchmark page details:

* [`front_end/app_pages/benchmark_page.py`](diffhunk://#diff-73ce862d8d1760170cad28cdc2f188a385036f4ad7d790facb281d3da7ab755aL19-R29): Updated benchmark file descriptions and added a new entry for "Claude 3.5 Sonnet for all tasks". Changed the title to "📈 Benchmarking Forecast Bot".